### PR TITLE
chore: Update .gitignore for development tool directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,5 +80,7 @@ docs/SYSTEM-RUNTIME-INTEGRATION-ANALYSIS.md
 # Backup files
 *.backup
 
-.augment/
-.zed/
+# Development tool directories (local configuration, should not be committed)
+/.augment/rules/
+/.serena/
+/.zed/


### PR DESCRIPTION
## 🎯 Overview

Update `.gitignore` to properly exclude local development tool directories that should not be committed to version control.

## 📝 Changes

Added specific gitignore entries for:

- `/.augment/rules/` - Augment AI configuration rules directory
- `/.serena/` - Serena MCP server cache/configuration directory
- `/.zed/` - Zed editor configuration directory

## 🔍 Details

### Before
```gitignore
.augment/
.zed/
```

### After
```gitignore
# Development tool directories (local configuration, should not be committed)
/.augment/rules/
/.serena/
/.zed/
```

## ✅ Benefits

1. **Clearer Intent** - Comment explains why these directories are ignored
2. **Specific Paths** - Uses `/` prefix to indicate root-level directories
3. **Complete Coverage** - Includes all three development tool directories
4. **Better Organization** - Groups related entries together

## 📋 Note

Existing tracked files in these directories remain tracked. This change only affects future files added to these directories. If needed, a future PR can remove existing tracked files from these directories.

## 🧪 Verification

Ran `git status` to confirm directories are properly ignored - no untracked files appear from these directories.

---

**Ready for review and merge!** 🚀

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author